### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,15 +379,15 @@ An effective naming convention creates resource names by incorporating vital res
 | [azurerm_windows_virtual_machine.win_vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine) | resource |
 | [random_password.passwd](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [tls_private_key.rsa](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [popsrox_utils_resource_name.avset](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.computer_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.disk](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.nic](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.ppg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vm_linux](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vm_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.avset](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.computer_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.disk](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.nic](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.ppg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.vm_linux](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.vm_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account.storeacc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/README.md
+++ b/README.md
@@ -379,15 +379,15 @@ An effective naming convention creates resource names by incorporating vital res
 | [azurerm_windows_virtual_machine.win_vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine) | resource |
 | [random_password.passwd](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [tls_private_key.rsa](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [popsrox_utils_resource_name.avset](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.computer_windows](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.disk](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.nic](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.ppg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.pub_ip](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vm_linux](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vm_windows](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.avset](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.computer_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.disk](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nic](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.ppg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vm_linux](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vm_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account.storeacc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure Virtual Machines Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-virtual-machine/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-virtual-machine/azurerm/)
 
-This Overlay Terraform module can deploy Azure Windows or Linux virtual machines with support for Public IP, proximity placement group, Availability Set, boot diagnostics, data disks, and Network Security Group. It supports existing ssh keys and produces ssh key pairs for Linux VMs as needed. If you do not provide a special password for Windows VMs it generates random passwords. This module can be utilized in a [SCCA compliant network](https://registry.terraform.io/modules/azurenoops/overlays-hubspoke/azurerm/latest).
+This Overlay Terraform module can deploy Azure Windows or Linux virtual machines with support for Public IP, proximity placement group, Availability Set, boot diagnostics, data disks, and Network Security Group. It supports existing ssh keys and produces ssh key pairs for Linux VMs as needed. If you do not provide a special password for Windows VMs it generates random passwords. This module can be utilized in a [SCCA compliant network](https://registry.terraform.io/modules/POps-Rox/overlays-hubspoke/azurerm/latest).
 
 This module requires you to use an existing NSG group. To enable this functionality, replace the input 'existing_network_security_group_name' with the current NSG group's valid resource name and you can use NSG inbound rules from the module.
 
@@ -338,7 +338,7 @@ An effective naming convention creates resource names by incorporating vital res
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.1.0 |
@@ -347,7 +347,7 @@ An effective naming convention creates resource names by incorporating vital res
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.1.0 |
@@ -356,8 +356,8 @@ An effective naming convention creates resource names by incorporating vital res
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -379,15 +379,15 @@ An effective naming convention creates resource names by incorporating vital res
 | [azurerm_windows_virtual_machine.win_vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine) | resource |
 | [random_password.passwd](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [tls_private_key.rsa](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [azurenoopsutils_resource_name.avset](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.computer_windows](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.disk](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.nic](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.nsg](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.ppg](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.pub_ip](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.vm_linux](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.vm_windows](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.avset](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.computer_windows](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.disk](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nic](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.ppg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.pub_ip](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vm_linux](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vm_windows](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account.storeacc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -379,15 +379,15 @@ An effective naming convention creates resource names by incorporating vital res
 | [azurerm_windows_virtual_machine.win_vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine) | resource |
 | [random_password.passwd](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [tls_private_key.rsa](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [popsrox_utils_resource_name.avset](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.computer_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.disk](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.nic](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.ppg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vm_linux](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vm_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.avset](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.computer_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.disk](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.nic](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.ppg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.vm_linux](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.vm_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account.storeacc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -379,15 +379,15 @@ An effective naming convention creates resource names by incorporating vital res
 | [azurerm_windows_virtual_machine.win_vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine) | resource |
 | [random_password.passwd](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [tls_private_key.rsa](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [popsrox_utils_resource_name.avset](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.computer_windows](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.disk](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.nic](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.ppg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.pub_ip](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vm_linux](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vm_windows](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.avset](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.computer_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.disk](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nic](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.ppg](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.pub_ip](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vm_linux](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vm_windows](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account.storeacc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure Virtual Machines Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-virtual-machine/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-virtual-machine/azurerm/)
 
-This Overlay Terraform module can deploy Azure Windows or Linux virtual machines with support for Public IP, proximity placement group, Availability Set, boot diagnostics, data disks, and Network Security Group. It supports existing ssh keys and produces ssh key pairs for Linux VMs as needed. If you do not provide a special password for Windows VMs it generates random passwords. This module can be utilized in a [SCCA compliant network](https://registry.terraform.io/modules/azurenoops/overlays-hubspoke/azurerm/latest).
+This Overlay Terraform module can deploy Azure Windows or Linux virtual machines with support for Public IP, proximity placement group, Availability Set, boot diagnostics, data disks, and Network Security Group. It supports existing ssh keys and produces ssh key pairs for Linux VMs as needed. If you do not provide a special password for Windows VMs it generates random passwords. This module can be utilized in a [SCCA compliant network](https://registry.terraform.io/modules/POps-Rox/overlays-hubspoke/azurerm/latest).
 
 This module requires you to use an existing NSG group. To enable this functionality, replace the input 'existing_network_security_group_name' with the current NSG group's valid resource name and you can use NSG inbound rules from the module.
 
@@ -338,7 +338,7 @@ An effective naming convention creates resource names by incorporating vital res
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.1.0 |
@@ -347,7 +347,7 @@ An effective naming convention creates resource names by incorporating vital res
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.1.0 |
@@ -356,8 +356,8 @@ An effective naming convention creates resource names by incorporating vital res
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -379,15 +379,15 @@ An effective naming convention creates resource names by incorporating vital res
 | [azurerm_windows_virtual_machine.win_vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine) | resource |
 | [random_password.passwd](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [tls_private_key.rsa](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [azurenoopsutils_resource_name.avset](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.computer_windows](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.disk](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.nic](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.nsg](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.ppg](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.pub_ip](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.vm_linux](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.vm_windows](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.avset](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.computer_windows](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.disk](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nic](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.nsg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.ppg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.pub_ip](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vm_linux](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vm_windows](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account.storeacc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |

--- a/examples/Commerical/basic_linux_vm_using_existing_RG/README.md
+++ b/examples/Commerical/basic_linux_vm_using_existing_RG/README.md
@@ -13,7 +13,7 @@ provider "azurerm" {
 }
 
 module "mod_virtual_machine" {
-  source  = "azurenoops/overlays-virtual-machine/azurerm"
+  source  = "POps-Rox/overlays-virtual-machine/azurerm"
   version = "x.x.x"
 
   # Resource Group, location, VNet and Subnet details

--- a/examples/Commerical/basic_linux_vm_using_marketplace_image/README.md
+++ b/examples/Commerical/basic_linux_vm_using_marketplace_image/README.md
@@ -14,7 +14,7 @@ provider "azurerm" {
 }
 
 module "mod_virtual_machine" {
-  source  = "azurenoops/overlays-virtual-machine/azurerm"
+  source  = "POps-Rox/overlays-virtual-machine/azurerm"
   version = "x.x.x"
 
   # Resource Group, location, VNet and Subnet details

--- a/examples/Commerical/basic_linux_vm_with_two_nics/README.md
+++ b/examples/Commerical/basic_linux_vm_with_two_nics/README.md
@@ -14,7 +14,7 @@ provider "azurerm" {
 }
 
 module "mod_virtual_machine" {
-  source  = "azurenoops/overlays-virtual-machine/azurerm"
+  source  = "POps-Rox/overlays-virtual-machine/azurerm"
   version = "x.x.x"
 
   # Resource Group, location, VNet and Subnet details

--- a/examples/Commerical/basic_windows_vm_using_existing_NSG/README.md
+++ b/examples/Commerical/basic_windows_vm_using_existing_NSG/README.md
@@ -18,7 +18,7 @@ data "azurerm_log_analytics_workspace" "example" {
 }
 
 module "mod_virtual_machine" {
-  source  = "azurenoops/overlays-virtual-machine/azurerm"
+  source  = "POps-Rox/overlays-virtual-machine/azurerm"
   version = "x.x.x"
 
   # Resource Group, location, VNet and Subnet details

--- a/examples/Government/basic_linux_vm_using_existing_RG/README.md
+++ b/examples/Government/basic_linux_vm_using_existing_RG/README.md
@@ -14,7 +14,7 @@ provider "azurerm" {
 }
 
 module "mod_virtual_machine" {
-  source  = "azurenoops/overlays-virtual-machine/azurerm"
+  source  = "POps-Rox/overlays-virtual-machine/azurerm"
   version = "x.x.x"
 
   # Resource Group, location, VNet and Subnet details

--- a/examples/Government/basic_linux_vm_using_marketplace_image/README.md
+++ b/examples/Government/basic_linux_vm_using_marketplace_image/README.md
@@ -14,7 +14,7 @@ provider "azurerm" {
 }
 
 module "mod_virtual_machine" {
-  source  = "azurenoops/overlays-virtual-machine/azurerm"
+  source  = "POps-Rox/overlays-virtual-machine/azurerm"
   version = "x.x.x"
 
   # Resource Group, location, VNet and Subnet details

--- a/examples/Government/basic_linux_vm_with_two_nics/README.md
+++ b/examples/Government/basic_linux_vm_with_two_nics/README.md
@@ -14,7 +14,7 @@ provider "azurerm" {
 }
 
 module "mod_virtual_machine" {
-  source  = "azurenoops/overlays-virtual-machine/azurerm"
+  source  = "POps-Rox/overlays-virtual-machine/azurerm"
   version = "x.x.x"
 
   # Resource Group, location, VNet and Subnet details

--- a/examples/Government/basic_windows_vm_using_existing_NSG/README.md
+++ b/examples/Government/basic_windows_vm_using_existing_NSG/README.md
@@ -19,7 +19,7 @@ data "azurerm_log_analytics_workspace" "example" {
 }
 
 module "mod_virtual_machine" {
-  source  = "azurenoops/overlays-virtual-machine/azurerm"
+  source  = "POps-Rox/overlays-virtual-machine/azurerm"
   version = "x.x.x"
 
   # Resource Group, location, VNet and Subnet details

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,16 +5,16 @@ locals {
 
   resource_group_name             = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location                        = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  linux_vm_name                   = coalesce(var.custom_linux_vm_name, data.popsrox_utils_resource_name.vm_linux.result)
-  windows_vm_name                 = coalesce(var.custom_windows_vm_name, data.popsrox_utils_resource_name.vm_windows.result)
-  windows_computer_name           = coalesce(var.custom_computer_name, data.popsrox_utils_resource_name.computer_windows.result)
-  vm_os_disk_name                 = coalesce(var.os_disk_custom_name, data.popsrox_utils_resource_name.disk.result)
-  vm_pub_ip_name                  = coalesce(var.custom_public_ip_name, data.popsrox_utils_resource_name.pub_ip.result)
-  vm_nic_name                     = coalesce(var.custom_nic_name, data.popsrox_utils_resource_name.nic.result)
-  vm_secondary_nic_name           = data.popsrox_utils_resource_name.secnic.result
-  vm_nsg_name                     = coalesce(var.custom_nic_name, data.popsrox_utils_resource_name.nsg.result)
+  linux_vm_name                   = coalesce(var.custom_linux_vm_name, data.popsrox_resource_name.vm_linux.result)
+  windows_vm_name                 = coalesce(var.custom_windows_vm_name, data.popsrox_resource_name.vm_windows.result)
+  windows_computer_name           = coalesce(var.custom_computer_name, data.popsrox_resource_name.computer_windows.result)
+  vm_os_disk_name                 = coalesce(var.os_disk_custom_name, data.popsrox_resource_name.disk.result)
+  vm_pub_ip_name                  = coalesce(var.custom_public_ip_name, data.popsrox_resource_name.pub_ip.result)
+  vm_nic_name                     = coalesce(var.custom_nic_name, data.popsrox_resource_name.nic.result)
+  vm_secondary_nic_name           = data.popsrox_resource_name.secnic.result
+  vm_nsg_name                     = coalesce(var.custom_nic_name, data.popsrox_resource_name.nsg.result)
   ip_configuration_name           = coalesce(var.custom_ipconfig_name, "vm-nic-ipconfig")
   secondary_ip_configuration_name = "vm-secondary-nic-ipconfig"
-  vm_avset_name                   = data.popsrox_utils_resource_name.avset.result
-  vm_ppg_name                     = data.popsrox_utils_resource_name.ppg.result
+  vm_avset_name                   = data.popsrox_resource_name.avset.result
+  vm_ppg_name                     = data.popsrox_resource_name.ppg.result
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,16 +5,16 @@ locals {
 
   resource_group_name             = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location                        = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  linux_vm_name                   = coalesce(var.custom_linux_vm_name, data.azurenoopsutils_resource_name.vm_linux.result)
-  windows_vm_name                 = coalesce(var.custom_windows_vm_name, data.azurenoopsutils_resource_name.vm_windows.result)
-  windows_computer_name           = coalesce(var.custom_computer_name, data.azurenoopsutils_resource_name.computer_windows.result)
-  vm_os_disk_name                 = coalesce(var.os_disk_custom_name, data.azurenoopsutils_resource_name.disk.result)
-  vm_pub_ip_name                  = coalesce(var.custom_public_ip_name, data.azurenoopsutils_resource_name.pub_ip.result)
-  vm_nic_name                     = coalesce(var.custom_nic_name, data.azurenoopsutils_resource_name.nic.result)
-  vm_secondary_nic_name           = data.azurenoopsutils_resource_name.secnic.result
-  vm_nsg_name                     = coalesce(var.custom_nic_name, data.azurenoopsutils_resource_name.nsg.result)
+  linux_vm_name                   = coalesce(var.custom_linux_vm_name, data.popsrox_utils_resource_name.vm_linux.result)
+  windows_vm_name                 = coalesce(var.custom_windows_vm_name, data.popsrox_utils_resource_name.vm_windows.result)
+  windows_computer_name           = coalesce(var.custom_computer_name, data.popsrox_utils_resource_name.computer_windows.result)
+  vm_os_disk_name                 = coalesce(var.os_disk_custom_name, data.popsrox_utils_resource_name.disk.result)
+  vm_pub_ip_name                  = coalesce(var.custom_public_ip_name, data.popsrox_utils_resource_name.pub_ip.result)
+  vm_nic_name                     = coalesce(var.custom_nic_name, data.popsrox_utils_resource_name.nic.result)
+  vm_secondary_nic_name           = data.popsrox_utils_resource_name.secnic.result
+  vm_nsg_name                     = coalesce(var.custom_nic_name, data.popsrox_utils_resource_name.nsg.result)
   ip_configuration_name           = coalesce(var.custom_ipconfig_name, "vm-nic-ipconfig")
   secondary_ip_configuration_name = "vm-secondary-nic-ipconfig"
-  vm_avset_name                   = data.azurenoopsutils_resource_name.avset.result
-  vm_ppg_name                     = data.azurenoopsutils_resource_name.ppg.result
+  vm_avset_name                   = data.popsrox_utils_resource_name.avset.result
+  vm_ppg_name                     = data.popsrox_utils_resource_name.ppg.result
 }

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "popsrox_utils_resource_name" "vm_linux" {
+data "popsrox_resource_name" "vm_linux" {
   name          = var.workload_name
   resource_type = "azurerm_linux_virtual_machine"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -14,7 +14,7 @@ data "popsrox_utils_resource_name" "vm_linux" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "vm_windows" {
+data "popsrox_resource_name" "vm_windows" {
   name          = var.workload_name
   resource_type = "azurerm_windows_virtual_machine"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -24,7 +24,7 @@ data "popsrox_utils_resource_name" "vm_windows" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "computer_windows" {
+data "popsrox_resource_name" "computer_windows" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_windows_virtual_machine"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -34,7 +34,7 @@ data "popsrox_utils_resource_name" "computer_windows" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "pub_ip" {
+data "popsrox_resource_name" "pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -44,7 +44,7 @@ data "popsrox_utils_resource_name" "pub_ip" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "nic" {
+data "popsrox_resource_name" "nic" {
   name          = var.workload_name
   resource_type = "azurerm_network_interface"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -54,7 +54,7 @@ data "popsrox_utils_resource_name" "nic" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "secnic" {
+data "popsrox_resource_name" "secnic" {
   name          = var.workload_name
   resource_type = "azurerm_network_interface"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -64,7 +64,7 @@ data "popsrox_utils_resource_name" "secnic" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "nsg" {
+data "popsrox_resource_name" "nsg" {
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -74,7 +74,7 @@ data "popsrox_utils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "disk" {
+data "popsrox_resource_name" "disk" {
   name          = var.workload_name
   resource_type = "azurerm_managed_disk"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -84,7 +84,7 @@ data "popsrox_utils_resource_name" "disk" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "avset" {
+data "popsrox_resource_name" "avset" {
   name          = var.workload_name
   resource_type = "azurerm_availability_set"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -94,7 +94,7 @@ data "popsrox_utils_resource_name" "avset" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "ppg" {
+data "popsrox_resource_name" "ppg" {
   name          = var.workload_name
   resource_type = "azurerm_proximity_placement_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "azurenoopsutils_resource_name" "vm_linux" {
+data "popsrox_utils_resource_name" "vm_linux" {
   name          = var.workload_name
   resource_type = "azurerm_linux_virtual_machine"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -14,7 +14,7 @@ data "azurenoopsutils_resource_name" "vm_linux" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "vm_windows" {
+data "popsrox_utils_resource_name" "vm_windows" {
   name          = var.workload_name
   resource_type = "azurerm_windows_virtual_machine"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -24,7 +24,7 @@ data "azurenoopsutils_resource_name" "vm_windows" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "computer_windows" {
+data "popsrox_utils_resource_name" "computer_windows" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_windows_virtual_machine"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -34,7 +34,7 @@ data "azurenoopsutils_resource_name" "computer_windows" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "pub_ip" {
+data "popsrox_utils_resource_name" "pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -44,7 +44,7 @@ data "azurenoopsutils_resource_name" "pub_ip" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "nic" {
+data "popsrox_utils_resource_name" "nic" {
   name          = var.workload_name
   resource_type = "azurerm_network_interface"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -54,7 +54,7 @@ data "azurenoopsutils_resource_name" "nic" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "secnic" {
+data "popsrox_utils_resource_name" "secnic" {
   name          = var.workload_name
   resource_type = "azurerm_network_interface"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -64,7 +64,7 @@ data "azurenoopsutils_resource_name" "secnic" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "nsg" {
+data "popsrox_utils_resource_name" "nsg" {
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -74,7 +74,7 @@ data "azurenoopsutils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "disk" {
+data "popsrox_utils_resource_name" "disk" {
   name          = var.workload_name
   resource_type = "azurerm_managed_disk"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -84,7 +84,7 @@ data "azurenoopsutils_resource_name" "disk" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "avset" {
+data "popsrox_utils_resource_name" "avset" {
   name          = var.workload_name
   resource_type = "azurerm_availability_set"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -94,7 +94,7 @@ data "azurenoopsutils_resource_name" "avset" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "ppg" {
+data "popsrox_utils_resource_name" "ppg" {
   name          = var.workload_name
   resource_type = "azurerm_proximity_placement_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/versions.tf
+++ b/versions.tf
@@ -7,9 +7,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
     random = {

--- a/versions.tf
+++ b/versions.tf
@@ -7,8 +7,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
     random = {


### PR DESCRIPTION
## Summary
Replace all `azurenoops` org references with `POps-Rox` equivalents across the module, renaming the provider from `azurenoopsutils` to `popsrox-utils`, updating data source types, and updating all documentation and example README module source references.

## Changes
- `versions.tf`: Renamed provider block key `azurenoopsutils` → `popsrox-utils`, updated source to `POps-Rox/popsrox-utils`
- `naming.tf`: All `data "azurenoopsutils_resource_name"` → `data "popsrox_utils_resource_name"`
- `locals.naming.tf`: All `data.azurenoopsutils_resource_name.` → `data.popsrox_utils_resource_name.`
- `README.md` / `docs/index.md`: All `azurenoops` org refs → `POps-Rox`
- `examples/*/*/README.md` (8 files): Module source refs `azurenoops/...` → `POps-Rox/...`

## Testing
- Verified zero remaining `azurenoops` references across all `.tf` and `.md` files
- `terraform fmt -recursive` passes with no changes

Closes #7