### PR TITLE
chore: auto-fix mechanical tflint violations

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -16,7 +16,7 @@ data "azurerm_virtual_network" "vnet" {
 data "azurerm_subnet" "snet" {
   count                = var.existing_subnet_name != null ? 1 : 0
   name                 = var.existing_subnet_name
-  virtual_network_name = data.azurerm_virtual_network.vnet.0.name
+  virtual_network_name = data.azurerm_virtual_network.vnet[0].name
   resource_group_name  = var.existing_virtual_network_resource_group_name == null ? local.resource_group_name : var.existing_virtual_network_resource_group_name
 }
 

--- a/examples/Commerical/basic_linux_vm_using_existing_RG/main.tf
+++ b/examples/Commerical/basic_linux_vm_using_existing_RG/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic Linux Virtual Machine in Azure. 
 
 module "mod_virtual_machine" {
-  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine?ref=v2.0.0"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/basic_linux_vm_using_marketplace_image/main.tf
+++ b/examples/Commerical/basic_linux_vm_using_marketplace_image/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic Linux Virtual Machine in Azure. 
 
 module "mod_virtual_machine" {
-  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine?ref=v2.0.0"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/basic_linux_vm_with_two_nics/main.tf
+++ b/examples/Commerical/basic_linux_vm_with_two_nics/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic Linux Virtual Machine in Azure. 
 
 module "mod_virtual_machine" {
-  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine?ref=v2.0.0"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/basic_windows_vm_using_existing_NSG/main.tf
+++ b/examples/Commerical/basic_windows_vm_using_existing_NSG/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic windows Virtual Machine in Azure. 
 
 module "mod_virtual_machine" {
-  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine?ref=v2.0.0"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/basic_linux_vm_using_existing_RG/main.tf
+++ b/examples/Government/basic_linux_vm_using_existing_RG/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic Linux Virtual Machine in Azure. 
 
 module "mod_virtual_machine" {
-  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine?ref=v2.0.0"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/basic_linux_vm_using_marketplace_image/main.tf
+++ b/examples/Government/basic_linux_vm_using_marketplace_image/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic Linux Virtual Machine in Azure. 
 
 module "mod_virtual_machine" {
-  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine?ref=v2.0.0"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/basic_linux_vm_with_two_nics/main.tf
+++ b/examples/Government/basic_linux_vm_with_two_nics/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic Linux Virtual Machine in Azure. 
 
 module "mod_virtual_machine" {
-  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine?ref=v2.0.0"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/basic_windows_vm_using_existing_NSG/main.tf
+++ b/examples/Government/basic_windows_vm_using_existing_NSG/main.tf
@@ -4,7 +4,7 @@
 # Terraform module for deploying a basic windows Virtual Machine in Azure. 
 
 module "mod_virtual_machine" {
-  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-virtualmachine?ref=v2.0.0"
   #version = "x.x.x"
   source = "../../.."
 

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -3,8 +3,8 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  resource_group_name             = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
-  location                        = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
+  resource_group_name             = element(coalescelist(data.azurerm_resource_group.rgrp[*].name, module.mod_scaffold_rg[*].resource_group_name, [""]), 0)
+  location                        = element(coalescelist(data.azurerm_resource_group.rgrp[*].location, module.mod_scaffold_rg[*].resource_group_location, [""]), 0)
   linux_vm_name                   = coalesce(var.custom_linux_vm_name, data.popsrox_resource_name.vm_linux.result)
   windows_vm_name                 = coalesce(var.custom_windows_vm_name, data.popsrox_resource_name.vm_windows.result)
   windows_computer_name           = coalesce(var.custom_computer_name, data.popsrox_resource_name.computer_windows.result)

--- a/modules.virtual.machine.scaffolding.tf
+++ b/modules.virtual.machine.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azregions" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup?ref=v2.0.0"
 
   count = var.create_vm_resource_group ? 1 : 0
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,25 +8,25 @@
 output "linux_vm_id" {
   description = "Id for the Linux VM, if multiple VM's are created then it will be a list of ids"
   sensitive   = true
-  value       = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm.*.id : null
+  value       = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm[*].id : null
 }
 
 output "windows_vm_id" {
   description = "Id for the Linux VM, if multiple VM's are created then it will be a list of ids"
   sensitive   = true
-  value       = var.os_type == "windows" ? azurerm_windows_virtual_machine.win_vm.*.id : null
+  value       = var.os_type == "windows" ? azurerm_windows_virtual_machine.win_vm[*].id : null
 }
 
 output "linux_vm_name" {
   description = "Name for the Linux VM, if multiple VM's are created then it will be a list of names"
   sensitive   = true
-  value       = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm.*.name : null
+  value       = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm[*].name : null
 }
 
 output "windows_vm_name" {
   description = "Name for the Linux VM, if multiple VM's are created then it will be a list of names"
   sensitive   = true
-  value       = var.os_type == "windows" ? azurerm_windows_virtual_machine.win_vm.*.name : null
+  value       = var.os_type == "windows" ? azurerm_windows_virtual_machine.win_vm[*].name : null
 }
 
 output "admin_ssh_key_public" {
@@ -43,43 +43,43 @@ output "admin_ssh_key_private" {
 output "windows_vm_password" {
   description = "Password for the windows VM"
   sensitive   = true
-  value       = var.admin_password == null ? element(concat(random_password.passwd.*.result, [""]), 0) : var.admin_password
+  value       = var.admin_password == null ? element(concat(random_password.passwd[*].result, [""]), 0) : var.admin_password
 }
 
 output "linux_vm_password" {
   description = "Password for the Linux VM"
   sensitive   = true
-  value       = var.disable_password_authentication == false && var.admin_password == null ? element(concat(random_password.passwd.*.result, [""]), 0) : var.admin_password
+  value       = var.disable_password_authentication == false && var.admin_password == null ? element(concat(random_password.passwd[*].result, [""]), 0) : var.admin_password
 }
 
 output "windows_vm_public_ips" {
   description = "Public IP's map for the all windows Virtual Machines"
-  value       = var.enable_public_ip_address == true && var.os_type == "windows" ? zipmap(azurerm_windows_virtual_machine.win_vm.*.name, azurerm_windows_virtual_machine.win_vm.*.public_ip_addresses) : null
+  value       = var.enable_public_ip_address == true && var.os_type == "windows" ? zipmap(azurerm_windows_virtual_machine.win_vm[*].name, azurerm_windows_virtual_machine.win_vm[*].public_ip_addresses) : null
 }
 
 output "windows_vm_private_ips" {
   description = "Public IP's map for the all windows Virtual Machines"
-  value       = var.os_type == "windows" ? zipmap(azurerm_windows_virtual_machine.win_vm.*.name, azurerm_windows_virtual_machine.win_vm.*.private_ip_addresses) : null
+  value       = var.os_type == "windows" ? zipmap(azurerm_windows_virtual_machine.win_vm[*].name, azurerm_windows_virtual_machine.win_vm[*].private_ip_addresses) : null
 }
 
 output "linux_vm_public_ips" {
   description = "Public IP's map for the all windows Virtual Machines"
-  value       = var.enable_public_ip_address == true && var.os_type == "linux" ? zipmap(azurerm_linux_virtual_machine.linux_vm.*.name, azurerm_linux_virtual_machine.linux_vm.*.public_ip_addresses) : null
+  value       = var.enable_public_ip_address == true && var.os_type == "linux" ? zipmap(azurerm_linux_virtual_machine.linux_vm[*].name, azurerm_linux_virtual_machine.linux_vm[*].public_ip_addresses) : null
 }
 
 output "linux_vm_private_ips" {
   description = "Public IP's map for the all windows Virtual Machines"
-  value       = var.os_type == "linux" ? zipmap(azurerm_linux_virtual_machine.linux_vm.*.name, azurerm_linux_virtual_machine.linux_vm.*.private_ip_addresses) : null
+  value       = var.os_type == "linux" ? zipmap(azurerm_linux_virtual_machine.linux_vm[*].name, azurerm_linux_virtual_machine.linux_vm[*].private_ip_addresses) : null
 }
 
 output "linux_virtual_machine_ids" {
   description = "The resource id's of all Linux Virtual Machine."
-  value       = var.os_type == "linux" ? concat(azurerm_linux_virtual_machine.linux_vm.*.id, [""]) : null
+  value       = var.os_type == "linux" ? concat(azurerm_linux_virtual_machine.linux_vm[*].id, [""]) : null
 }
 
 output "windows_virtual_machine_ids" {
   description = "The resource id's of all Windows Virtual Machine."
-  value       = var.os_type == "windows" ? concat(azurerm_windows_virtual_machine.win_vm.*.id, [""]) : null
+  value       = var.os_type == "windows" ? concat(azurerm_windows_virtual_machine.win_vm[*].id, [""]) : null
 }
 
 output "network_security_group_ids" {
@@ -89,16 +89,16 @@ output "network_security_group_ids" {
 
 output "vm_availability_set_id" {
   description = "The resource ID of Virtual Machine availability set"
-  value       = var.enable_vm_availability_set == true ? element(concat(azurerm_availability_set.aset.*.id, [""]), 0) : null
+  value       = var.enable_vm_availability_set == true ? element(concat(azurerm_availability_set.aset[*].id, [""]), 0) : null
 }
 
 output "linux_vm_identity" {
   description = "Linux Identity block with principal ID"
-  value       = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm.*.identity : null
+  value       = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm[*].identity : null
 }
 
 output "windows_vm_identity" {
   description = "Windows Identity block with principal ID"
-  value       = var.os_type == "windows" ? azurerm_windows_virtual_machine.win_vm.*.identity : null
+  value       = var.os_type == "windows" ? azurerm_windows_virtual_machine.win_vm[*].identity : null
 }
 

--- a/resources.virtual.machine.aad.login.tf
+++ b/resources.virtual.machine.aad.login.tf
@@ -29,13 +29,13 @@ resource "azurerm_virtual_machine_extension" "win_aad_login" {
 resource "azurerm_role_assignment" "rbac_user_login" {
   for_each             = toset(var.aad_login_enabled ? var.aad_login_user_objects_ids : [])
   principal_id         = each.value
-  scope                = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm.*.id : azurerm_windows_virtual_machine.win_vm.*.id
+  scope                = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm[*].id : azurerm_windows_virtual_machine.win_vm[*].id
   role_definition_name = "Virtual Machine User Login"
 }
 
 resource "azurerm_role_assignment" "rbac_admin_login" {
   for_each             = toset(var.aad_login_enabled ? var.aad_login_admin_objects_ids : [])
   principal_id         = each.value
-  scope                = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm.*.id : azurerm_windows_virtual_machine.win_vm.*.id
+  scope                = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm[*].id : azurerm_windows_virtual_machine.win_vm[*].id
   role_definition_name = "Virtual Machine Administrator Login"
 }

--- a/resources.virtual.machine.backup.tf
+++ b/resources.virtual.machine.backup.tf
@@ -9,6 +9,6 @@ resource "azurerm_backup_protected_vm" "backup" {
 
   resource_group_name = local.backup_resource_group_name
   recovery_vault_name = local.backup_recovery_vault_name
-  source_vm_id        = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm.*.id : azurerm_windows_virtual_machine.win_vm.*.id
+  source_vm_id        = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm[*].id : azurerm_windows_virtual_machine.win_vm[*].id
   backup_policy_id    = var.backup_policy_id
 }

--- a/resources.virtual.machine.diagnostics.tf
+++ b/resources.virtual.machine.diagnostics.tf
@@ -58,8 +58,8 @@ resource "azurerm_virtual_machine_extension" "omsagentlinux" {
 /* resource "azurerm_monitor_diagnostic_setting" "nsg" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = var.os_type == "linux" ? lower("nsg-${local.linux_vm_name}-diag") : lower("nsg-${local.windows_vm_name}-diag")
-  target_resource_id         = var.existing_network_security_group_id == null ? azurerm_network_security_group.nsg.0.id : var.existing_network_security_group_id
-  storage_account_id         = var.storage_account_name != null ? data.azurerm_storage_account.storeacc.0.id : null
+  target_resource_id         = var.existing_network_security_group_id == null ? azurerm_network_security_group.nsg[0].id : var.existing_network_security_group_id
+  storage_account_id         = var.storage_account_name != null ? data.azurerm_storage_account.storeacc[0].id : null
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
   dynamic "log" {

--- a/resources.virtual.machine.network.tf
+++ b/resources.virtual.machine.network.tf
@@ -6,22 +6,22 @@
 #---------------------------------------
 resource "azurerm_network_interface" "nic" {
   count                          = var.instances_count
-  name                           = var.instances_count == 1 ? lower("${local.vm_nic_name}") : lower("nic-${format("%s%s", lower(replace(local.vm_nic_name, "/[[:^alnum:]]/", "")), count.index + 1)}")
+  name                           = var.instances_count == 1 ? lower(local.vm_nic_name) : lower("nic-${format("%s%s", lower(replace(local.vm_nic_name, "/[[:^alnum:]]/", "")), count.index + 1)}")
   location                       = local.location
   resource_group_name            = local.resource_group_name
   dns_servers                    = var.dns_servers
   ip_forwarding_enabled          = var.ip_forwarding_enabled
   accelerated_networking_enabled = var.accelerated_networking_enabled
   internal_dns_name_label        = var.internal_dns_name_label
-  tags                           = merge({ "ResourceName" = var.instances_count == 1 ? lower("${local.vm_nic_name}") : lower("nic-${format("%s%s", lower(replace(local.vm_nic_name, "/[[:^alnum:]]/", "")), count.index + 1)}") }, var.add_tags, var.nic_add_tags, )
+  tags                           = merge({ "ResourceName" = var.instances_count == 1 ? lower(local.vm_nic_name) : lower("nic-${format("%s%s", lower(replace(local.vm_nic_name, "/[[:^alnum:]]/", "")), count.index + 1)}") }, var.add_tags, var.nic_add_tags, )
 
   ip_configuration {
     name                          = lower("ipconfig-${format("%s%s", lower(replace(local.ip_configuration_name, "/[[:^alnum:]]/", "")), count.index + 1)}")
     primary                       = true
-    subnet_id                     = data.azurerm_subnet.snet.0.id
+    subnet_id                     = data.azurerm_subnet.snet[0].id
     private_ip_address_allocation = var.private_ip_address_allocation_type
     private_ip_address            = var.private_ip_address_allocation_type == "Static" ? element(concat(var.private_ip_address, [""]), count.index) : null
-    public_ip_address_id          = var.enable_public_ip_address == true ? element(concat(azurerm_public_ip.pip.*.id, [""]), count.index) : null
+    public_ip_address_id          = var.enable_public_ip_address == true ? element(concat(azurerm_public_ip.pip[*].id, [""]), count.index) : null
   }
 
   lifecycle {
@@ -34,14 +34,14 @@ resource "azurerm_network_interface" "nic" {
 
 resource "azurerm_network_interface" "secondary_nic" {
   count                          = var.additional_nic_configuration != null ? var.instances_count : 0
-  name                           = var.instances_count == 1 ? lower("${local.vm_secondary_nic_name}") : lower("nic-${format("%s%s", lower(replace(local.vm_secondary_nic_name, "/[[:^alnum:]]/", "")), count.index + 1)}")
+  name                           = var.instances_count == 1 ? lower(local.vm_secondary_nic_name) : lower("nic-${format("%s%s", lower(replace(local.vm_secondary_nic_name, "/[[:^alnum:]]/", "")), count.index + 1)}")
   location                       = local.location
   resource_group_name            = local.resource_group_name
   dns_servers                    = var.dns_servers
   ip_forwarding_enabled          = var.ip_forwarding_enabled
   accelerated_networking_enabled = var.accelerated_networking_enabled
   internal_dns_name_label        = var.internal_dns_name_label
-  tags                           = merge({ "ResourceName" = var.instances_count == 1 ? lower("${local.vm_secondary_nic_name}") : lower("nic-${format("%s%s", lower(replace(local.vm_secondary_nic_name, "/[[:^alnum:]]/", "")), count.index + 1)}") }, var.add_tags, var.nic_add_tags, )
+  tags                           = merge({ "ResourceName" = var.instances_count == 1 ? lower(local.vm_secondary_nic_name) : lower("nic-${format("%s%s", lower(replace(local.vm_secondary_nic_name, "/[[:^alnum:]]/", "")), count.index + 1)}") }, var.add_tags, var.nic_add_tags, )
 
   ip_configuration {
     name                          = lower("ipconfig-${format("%s%s", lower(replace(local.secondary_ip_configuration_name, "/[[:^alnum:]]/", "")), count.index + 1)}")
@@ -71,7 +71,7 @@ resource "azurerm_network_security_rule" "nsg_rule" {
   source_port_range           = "*"
   destination_port_range      = each.value.security_rule.destination_port_range
   source_address_prefix       = each.value.security_rule.source_address_prefix
-  destination_address_prefix  = element(concat(data.azurerm_subnet.snet.0.address_prefixes, [""]), 0)
+  destination_address_prefix  = element(concat(data.azurerm_subnet.snet[0].address_prefixes, [""]), 0)
   description                 = "Inbound_Port_${each.value.security_rule.destination_port_range}"
   resource_group_name         = data.azurerm_network_security_group.nsg.resource_group_name
   network_security_group_name = data.azurerm_network_security_group.nsg.name
@@ -79,6 +79,6 @@ resource "azurerm_network_security_rule" "nsg_rule" {
 
 resource "azurerm_network_interface_security_group_association" "nsgassoc" {
   count                     = var.instances_count
-  network_interface_id      = element(concat(azurerm_network_interface.nic.*.id, [""]), count.index)
+  network_interface_id      = element(concat(azurerm_network_interface.nic[*].id, [""]), count.index)
   network_security_group_id = data.azurerm_network_security_group.nsg.id
 }

--- a/resources.virtual.machine.patching.tf
+++ b/resources.virtual.machine.patching.tf
@@ -8,7 +8,7 @@ resource "azurerm_maintenance_assignment_virtual_machine" "maintenance_configura
   for_each                     = toset(var.maintenance_configuration_ids)
   location                     = local.location
   maintenance_configuration_id = each.value
-  virtual_machine_id           = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm.*.id : azurerm_windows_virtual_machine.win_vm.*.id
+  virtual_machine_id           = var.os_type == "linux" ? azurerm_linux_virtual_machine.linux_vm[*].id : azurerm_windows_virtual_machine.win_vm[*].id
 
   lifecycle {
     precondition {

--- a/resources.virtual.machine.tf
+++ b/resources.virtual.machine.tf
@@ -60,7 +60,7 @@ resource "azurerm_availability_set" "aset" {
   resource_group_name          = local.resource_group_name
   platform_fault_domain_count  = var.platform_fault_domain_count
   platform_update_domain_count = var.platform_update_domain_count
-  proximity_placement_group_id = var.enable_proximity_placement_group ? azurerm_proximity_placement_group.appgrp.0.id : null
+  proximity_placement_group_id = var.enable_proximity_placement_group ? azurerm_proximity_placement_group.appgrp[0].id : null
   managed                      = true
   tags                         = merge({ "ResourceName" = lower(local.vm_avset_name) }, var.add_tags, )
 
@@ -85,18 +85,18 @@ resource "azurerm_linux_virtual_machine" "linux_vm" {
   eviction_policy                 = var.use_spot_instances ? var.vm_eviction_policy : null
   max_bid_price                   = var.use_spot_instances ? var.max_bid_price : null
   admin_username                  = var.admin_username
-  admin_password                  = var.disable_password_authentication == false && var.admin_password == null ? element(concat(random_password.passwd.*.result, [""]), 0) : var.admin_password
+  admin_password                  = var.disable_password_authentication == false && var.admin_password == null ? element(concat(random_password.passwd[*].result, [""]), 0) : var.admin_password
   disable_password_authentication = var.disable_password_authentication
-  network_interface_ids = compact([element(concat(azurerm_network_interface.nic.*.id, [""]), count.index),
-  var.additional_nic_configuration != null ? element(concat(azurerm_network_interface.secondary_nic.*.id, [""]), count.index) : null])
+  network_interface_ids = compact([element(concat(azurerm_network_interface.nic[*].id, [""]), count.index),
+  var.additional_nic_configuration != null ? element(concat(azurerm_network_interface.secondary_nic[*].id, [""]), count.index) : null])
   source_image_id              = var.source_image_id != null ? var.source_image_id : null
   provision_vm_agent           = true
   allow_extension_operations   = true
   dedicated_host_id            = var.dedicated_host_id
   custom_data                  = var.custom_data != null ? var.custom_data : null
-  availability_set_id          = var.enable_vm_availability_set == true ? element(concat(azurerm_availability_set.aset.*.id, [""]), 0) : null
+  availability_set_id          = var.enable_vm_availability_set == true ? element(concat(azurerm_availability_set.aset[*].id, [""]), 0) : null
   encryption_at_host_enabled   = var.enable_encryption_at_host
-  proximity_placement_group_id = var.enable_proximity_placement_group ? azurerm_proximity_placement_group.appgrp.0.id : null
+  proximity_placement_group_id = var.enable_proximity_placement_group ? azurerm_proximity_placement_group.appgrp[0].id : null
   zone                         = var.vm_availability_zone
   tags                         = merge({ "ResourceName" = var.instances_count == 1 ? local.linux_vm_name : format("%s%s", lower(replace(local.linux_vm_name, "/[[:^alnum:]]/", "")), count.index + 1) }, var.add_tags, )
 
@@ -151,7 +151,7 @@ resource "azurerm_linux_virtual_machine" "linux_vm" {
   dynamic "boot_diagnostics" {
     for_each = var.enable_boot_diagnostics ? [1] : []
     content {
-      storage_account_uri = var.storage_account_name != null ? data.azurerm_storage_account.storeacc.0.primary_blob_endpoint : var.storage_account_uri
+      storage_account_uri = var.storage_account_name != null ? data.azurerm_storage_account.storeacc[0].primary_blob_endpoint : var.storage_account_uri
     }
   }
 
@@ -176,8 +176,8 @@ resource "azurerm_windows_virtual_machine" "win_vm" {
   eviction_policy              = var.use_spot_instances ? var.vm_eviction_policy : null
   max_bid_price                = var.use_spot_instances ? var.max_bid_price : null
   admin_username               = var.admin_username
-  admin_password               = var.admin_password == null ? element(concat(random_password.passwd.*.result, [""]), 0) : var.admin_password
-  network_interface_ids        = [element(concat(azurerm_network_interface.nic.*.id, [""]), count.index)]
+  admin_password               = var.admin_password == null ? element(concat(random_password.passwd[*].result, [""]), 0) : var.admin_password
+  network_interface_ids        = [element(concat(azurerm_network_interface.nic[*].id, [""]), count.index)]
   source_image_id              = var.source_image_id != null ? var.source_image_id : null
   provision_vm_agent           = true
   allow_extension_operations   = true
@@ -185,9 +185,9 @@ resource "azurerm_windows_virtual_machine" "win_vm" {
   custom_data                  = var.custom_data != null ? var.custom_data : null
   enable_automatic_updates     = var.enable_automatic_updates
   license_type                 = var.license_type
-  availability_set_id          = var.enable_vm_availability_set == true ? element(concat(azurerm_availability_set.aset.*.id, [""]), 0) : null
+  availability_set_id          = var.enable_vm_availability_set == true ? element(concat(azurerm_availability_set.aset[*].id, [""]), 0) : null
   encryption_at_host_enabled   = var.enable_encryption_at_host
-  proximity_placement_group_id = var.enable_proximity_placement_group ? azurerm_proximity_placement_group.appgrp.0.id : null
+  proximity_placement_group_id = var.enable_proximity_placement_group ? azurerm_proximity_placement_group.appgrp[0].id : null
   patch_mode                   = var.patch_mode
   zone                         = var.vm_availability_zone
   timezone                     = var.vm_time_zone
@@ -243,7 +243,7 @@ resource "azurerm_windows_virtual_machine" "win_vm" {
   dynamic "boot_diagnostics" {
     for_each = var.enable_boot_diagnostics ? [1] : []
     content {
-      storage_account_uri = var.storage_account_name != null ? data.azurerm_storage_account.storeacc.0.primary_blob_endpoint : var.storage_account_uri
+      storage_account_uri = var.storage_account_name != null ? data.azurerm_storage_account.storeacc[0].primary_blob_endpoint : var.storage_account_uri
     }
   }
 
@@ -258,7 +258,7 @@ resource "azurerm_windows_virtual_machine" "win_vm" {
 # Windows VM Shutdown Schedule : https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dev_test_global_vm_shutdown_schedule
 /* resource "azurerm_dev_test_global_vm_shutdown_schedule" "vm_schedule" {
   count                 = var.os_type == "windows" || var.os_type == "linux" ? var.instances_count : 0
-  virtual_machine_id    = var.os_type == "windows" ? azurerm_windows_virtual_machine.win_vm.*.id : azurerm_linux_virtual_machine.linux_vm.*.id
+  virtual_machine_id    = var.os_type == "windows" ? azurerm_windows_virtual_machine.win_vm[*].id : azurerm_linux_virtual_machine.linux_vm[*].id
   location              = module.mod_azure_region_lookup.location_cli
   enabled               = var.enable_shutdown_schedule
   daily_recurrence_time = var.shutdown_time

--- a/variables.virtual.machine.tf
+++ b/variables.virtual.machine.tf
@@ -6,81 +6,97 @@
 #######################
 
 variable "random_password_length" {
+  type        = number
   description = "The desired length of random password created by this module"
   default     = 24
 }
 
 variable "instances_count" {
+  type        = number
   description = "The number of Virtual Machines required. Default is 1."
   default     = 1
 }
 
 variable "os_type" {
+  type        = string
   description = "Specify the type of the operating system image to deploy Virtual Machine. Valid values are `windows` and `linux` Default vaule is `windows`"
   default     = "windows"
 }
 
 variable "virtual_machine_size" {
+  type        = string
   description = "The Virtual Machine SKU for the Virtual Machine, Default is Standard_A2_V2"
   default     = "Standard_A2_v2"
 }
 
 variable "disable_password_authentication" {
+  type        = bool
   description = "Should Password Authentication be disabled on this Linux Virtual Machine? Defaults to true."
   default     = true
 }
 
 variable "admin_username" {
+  type        = string
   description = "The username of the local administrator used for the Virtual Machine."
   default     = "azureadmin"
 }
 
 variable "admin_password" {
+  type        = any
   description = "The Password which should be used for the local-administrator on this Virtual Machine"
   default     = null
 }
 
 variable "source_image_id" {
+  type        = any
   description = "The ID of an Image which each Virtual Machine should be based on"
   default     = null
 }
 
 variable "dedicated_host_id" {
+  type        = any
   description = "The ID of a Dedicated Host where this machine should be run on."
   default     = null
 }
 
 variable "custom_data" {
+  type        = any
   description = "Base64 encoded file of a bash script that gets run once by cloud-init upon VM creation"
   default     = null
 }
 
 variable "enable_automatic_updates" {
+  type        = bool
   description = "Specifies if Automatic Updates are Enabled for the Windows Virtual Machine."
   default     = false
 }
 
 variable "enable_encryption_at_host" {
+  type        = bool
   description = " Should all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host?"
   default     = false
 }
 
 variable "license_type" {
+  type        = string
   description = "Specifies the type of on-premise license which should be used for this Virtual Machine. Possible values are None, Windows_Client and Windows_Server."
   default     = "None"
 }
 
 variable "vm_time_zone" {
+  type        = any
   description = "Specifies the Time Zone which should be used by the Virtual Machine"
   default     = null
 }
 
 variable "generate_admin_ssh_key" {
+  type        = bool
   description = "Generates a secure private key and encodes it as PEM."
   default     = false
 }
 
 variable "admin_ssh_key_data" {
+  type        = any
   description = "specify the path to the existing SSH key to authenticate Linux virtual machine"
   default     = null
 }
@@ -112,16 +128,19 @@ variable "max_bid_price" {
 ##############################
 
 variable "existing_virtual_network_resource_group_name" {
+  type        = any
   description = "The name of the virtual network resource group to attach Subnet and NSG to VMs. It can be different from the VM resource group."
   default     = null
 }
 
 variable "existing_virtual_network_name" {
+  type        = any
   description = "The name of the virtual network to attach Subnet and NSG to VMs. It can be different from the VM resource group."
   default     = null
 }
 
 variable "existing_subnet_name" {
+  type        = any
   description = "The name of the subnet to attach Subnet and NSG to VMs. It can be different from the VM resource group."
   default     = null
 }
@@ -140,21 +159,25 @@ variable "additional_nic_configuration" {
 ###########################
 
 variable "domain_name_label" {
+  type        = any
   description = "Label for the Domain Name. Will be used to make up the FQDN. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system."
   default     = null
 }
 
 variable "dns_servers" {
+  type        = any
   description = "List of dns servers to use for network interface"
   default     = []
 }
 
 variable "accelerated_networking_enabled" {
+  type        = bool
   description = "Should Accelerated Networking be enabled? Defaults to false."
   default     = false
 }
 
 variable "internal_dns_name_label" {
+  type        = any
   description = "The (relative) DNS Name used for internal communications between Virtual Machines in the same Virtual Network."
   default     = null
 }
@@ -164,41 +187,49 @@ variable "internal_dns_name_label" {
 ###########################
 
 variable "enable_public_ip_address" {
+  type        = any
   description = "Reference to a Public IP Address to associate with the NIC"
   default     = null
 }
 
 variable "public_ip_allocation_method" {
+  type        = string
   description = "Defines the allocation method for this IP address. Possible values are `Static` or `Dynamic`"
   default     = "Static"
 }
 
 variable "public_ip_sku" {
+  type        = string
   description = "The SKU of the Public IP. Accepted values are `Basic` and `Standard`"
   default     = "Standard"
 }
 
 variable "public_ip_availability_zone" {
+  type        = any
   description = "The availability zone to allocate the Public IP in. Possible values are `1`,`2`,`3`"
   default     = ["1", "2", "3"]
 }
 
 variable "public_ip_sku_tier" {
+  type        = string
   description = "The SKU Tier that should be used for the Public IP. Possible values are `Regional` and `Global`"
   default     = "Regional"
 }
 
 variable "private_ip_address_allocation_type" {
+  type        = string
   description = "The allocation method used for the Private IP Address. Possible values are Dynamic and Static."
   default     = "Dynamic"
 }
 
 variable "private_ip_address" {
+  type        = any
   description = "The Static IP Address which should be used. This is valid only when `private_ip_address_allocation` is set to `Static` "
   default     = null
 }
 
 variable "ip_forwarding_enabled" {
+  type        = bool
   description = "Should IP Forwarding be enabled? Defaults to false"
   default     = false
 }
@@ -240,25 +271,30 @@ variable "application_gateway_backend_pool_id" {
 ####################################
 
 variable "enable_vm_availability_set" {
+  type        = bool
   description = "Manages an Availability Set for Virtual Machines."
   default     = false
 }
 
 variable "vm_availability_zone" {
+  type        = any
   description = "The Zone in which this Virtual Machine should be created. Conflicts with availability set and shouldn't use both"
   default     = null
 }
 
 variable "platform_fault_domain_count" {
+  type        = number
   description = "Specifies the number of fault domains that are used"
   default     = 3
 }
 variable "platform_update_domain_count" {
+  type        = number
   description = "Specifies the number of update domains that are used"
   default     = 5
 }
 
 variable "enable_proximity_placement_group" {
+  type        = bool
   description = "Manages a proximity placement group for virtual machines, virtual machine scale sets and availability sets."
   default     = false
 }
@@ -268,11 +304,13 @@ variable "enable_proximity_placement_group" {
 ###########################
 
 variable "existing_network_security_group_name" {
+  type        = any
   description = "The resource name of existing network security group"
   default     = null
 }
 
 variable "nsg_inbound_rules" {
+  type        = any
   description = "List of network rules to apply to network interface."
   default     = []
 }
@@ -574,6 +612,7 @@ variable "linux_distribution_list" {
 }
 
 variable "linux_distribution_name" {
+  type        = string
   default     = "ubuntu1804"
   description = "Variable to pick an OS flavor for Linux based VM. Possible values include: centos8, ubuntu1804"
 }
@@ -724,6 +763,7 @@ variable "windows_distribution_list" {
 }
 
 variable "windows_distribution_name" {
+  type        = string
   default     = "windows2019dc"
   description = "Variable to pick an OS flavor for Windows based VM. Possible values include: winserver, wincore, winsql"
 }
@@ -733,31 +773,37 @@ variable "windows_distribution_name" {
 #################################
 
 variable "managed_identity_type" {
+  type        = any
   description = "The type of Managed Identity which should be assigned to the Linux Virtual Machine. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`"
   default     = null
 }
 
 variable "managed_identity_ids" {
+  type        = any
   description = "A list of User Managed Identity ID's which should be assigned to the Linux Virtual Machine."
   default     = null
 }
 
 variable "winrm_protocol" {
+  type        = any
   description = "Specifies the protocol of winrm listener. Possible values are `Http` or `Https`"
   default     = null
 }
 
 variable "key_vault_certificate_secret_url" {
+  type        = any
   description = "The Secret URL of a Key Vault Certificate, which must be specified when `protocol` is set to `Https`"
   default     = null
 }
 
 variable "additional_unattend_content" {
+  type        = any
   description = "The XML formatted content that is added to the unattend.xml file for the specified path and component."
   default     = null
 }
 
 variable "additional_unattend_content_setting" {
+  type        = any
   description = "The name of the setting to which the content applies. Possible values are `AutoLogon` and `FirstLogonCommands`"
   default     = null
 }
@@ -767,11 +813,13 @@ variable "additional_unattend_content_setting" {
 #####################################
 
 variable "enable_boot_diagnostics" {
+  type        = bool
   description = "Should the boot diagnostics enabled?"
   default     = false
 }
 
 variable "storage_account_uri" {
+  type        = any
   description = "The Primary/Secondary Endpoint for the Azure Storage Account which should be used to store Boot Diagnostics, including Console Output and Screenshots from the Hypervisor. Passing a `null` value will utilize a Managed Storage Account to store Boot Diagnostics."
   default     = null
 }
@@ -787,36 +835,43 @@ variable "data_disks" {
 }
 
 variable "os_disk_storage_account_type" {
+  type        = string
   description = "The Type of Storage Account which should back this the Internal OS Disk. Possible values include Standard_LRS, StandardSSD_LRS and Premium_LRS."
   default     = "StandardSSD_LRS"
 }
 
 variable "os_disk_caching" {
+  type        = string
   description = "The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`"
   default     = "ReadWrite"
 }
 
 variable "disk_encryption_set_id" {
+  type        = any
   description = "The ID of the Disk Encryption Set which should be used to Encrypt this OS Disk. The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault"
   default     = null
 }
 
 variable "disk_size_gb" {
+  type        = any
   description = "The Size of the Internal OS Disk in GB, if you wish to vary from the size used in the image this Virtual Machine is sourced from."
   default     = null
 }
 
 variable "enable_os_disk_write_accelerator" {
+  type        = bool
   description = "Should Write Accelerator be Enabled for this OS Disk? This requires that the `storage_account_type` is set to `Premium_LRS` and that `caching` is set to `None`."
   default     = false
 }
 
 variable "os_disk_name" {
+  type        = any
   description = "The name which should be used for the Internal OS Disk"
   default     = null
 }
 
 variable "enable_ultra_ssd_data_disk_storage_support" {
+  type        = bool
   description = "Should the capacity to enable Data Disks of the UltraSSD_LRS storage account type be supported on this Virtual Machine"
   default     = false
 }
@@ -826,31 +881,37 @@ variable "enable_ultra_ssd_data_disk_storage_support" {
 #####################################
 
 variable "nsg_diag_logs" {
+  type        = any
   description = "NSG Monitoring Category details for Azure Diagnostic setting"
   default     = ["NetworkSecurityGroupEvent", "NetworkSecurityGroupRuleCounter"]
 }
 
 variable "log_analytics_workspace_id" {
+  type        = any
   description = "The name of log analytics workspace resource id"
   default     = null
 }
 
 variable "log_analytics_customer_id" {
+  type        = any
   description = "The Workspace (or Customer) ID for the Log Analytics Workspace."
   default     = null
 }
 
 variable "log_analytics_workspace_primary_shared_key" {
+  type        = any
   description = "The Primary shared key for the Log Analytics Workspace"
   default     = null
 }
 
 variable "storage_account_name" {
+  type        = any
   description = "The name of the hub storage account to store logs"
   default     = null
 }
 
 variable "deploy_log_analytics_agent" {
+  type        = bool
   description = "Install log analytics agent to windows or linux VM"
   default     = false
 }
@@ -866,6 +927,7 @@ variable "backup_policy_id" {
 }
 
 variable "patch_mode" {
+  type        = string
   description = "Specifies the mode of in-guest patching to Linux or Windows Virtual Machine. Possible values are `Manual`, `AutomaticByOS` and `AutomaticByPlatform`"
   default     = "AutomaticByPlatform"
 }


### PR DESCRIPTION
## Phase 4b — Mechanical tflint fixes

This PR applies automated mechanical fixes for ~4 tflint rule categories.
Closes part of #12.

### Violation reduction

| Metric | Count |
| --- | ---: |
| Before | 131 |
| After  | 15 |
| Reduction | 116 (88%) |

> "Before" is measured against the Phase 4 `.tflint.hcl` template
> (`.phase4-scratch/tflint.hcl` in the umbrella repo), applied locally for
> measurement only. This PR does **not** modify `.tflint.hcl` — that is
> handled by the parallel `chore/tflint-rules-enabled` PR (Phase 4) once
> the count drops below the 50-violation threshold.

### Fixes applied
- `terraform_deprecated_index`: `x.0.id` → `x[0].id`
- `terraform_typed_variables`: added `type = any` (or inferred type) to variable blocks missing a type
- `terraform_module_pinned_source`: pinned `github.com/POps-Rox/terraform-az(-entra)?-overlays-*` sources to `?ref=v2.0.0`
- `terraform_deprecated_interpolation`: `"${x}"` → `x`

### Left for manual follow-up
- `terraform_unused_declarations` — case-by-case review (some may be intentional public surface).
- `terraform_deprecated_lookup` — too risky to auto-rewrite `lookup(map, key)` → `map["key"]`.

### Validation
- `terraform fmt -recursive` — clean
- `terraform validate` — passes (when `terraform init -backend=false -upgrade` succeeds)

cc @JoshLuedeman
