### PR TITLE
chore: classify and clean up unused declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Removed
+- Removed unused declarations flagged by `tflint terraform_unused_declarations`:
+  - **WIP feature stubs** (tracked in #15): `attach_load_balancer`, `load_balancer_backend_pool_id`, `attach_application_gateway`, `application_gateway_backend_pool_id`, `extensions_add_tags`, `os_disk_overwrite_tags`, `os_disk_tagging_enabled`, `custom_dcr_name`, `nsg_diag_logs`, `log_analytics_workspace_id`.
+  - **Dead code**: `data.azurerm_client_config.current`, `data.popsrox_resource_name.nsg`, `local.default_tags`, `local.linux_domain_name_label`, `local.windows_domain_name_label`, `local.vm_nsg_name`, and the cascade-orphaned `default_tags_enabled` input.
+  - Removed commented-out `azurerm_monitor_diagnostic_setting.nsg` block in `resources.virtual.machine.diagnostics.tf`.
+
 ## 2.0.0 - 2025-05-11
 
 ### Changed

--- a/data.tf
+++ b/data.tf
@@ -1,9 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# remove file if not needed
-data "azurerm_client_config" "current" {}
-
 #----------------------------------------------------------
 # VNet, Subnet selection & Random Resources
 #----------------------------------------------------------

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -12,7 +12,6 @@ locals {
   vm_pub_ip_name                  = coalesce(var.custom_public_ip_name, data.popsrox_resource_name.pub_ip.result)
   vm_nic_name                     = coalesce(var.custom_nic_name, data.popsrox_resource_name.nic.result)
   vm_secondary_nic_name           = data.popsrox_resource_name.secnic.result
-  vm_nsg_name                     = coalesce(var.custom_nic_name, data.popsrox_resource_name.nsg.result)
   ip_configuration_name           = coalesce(var.custom_ipconfig_name, "vm-nic-ipconfig")
   secondary_ip_configuration_name = "vm-secondary-nic-ipconfig"
   vm_avset_name                   = data.popsrox_resource_name.avset.result

--- a/locals.tags.tf
+++ b/locals.tags.tf
@@ -1,13 +1,2 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-
-#------------------------------------------------------------
-# Local Tags configuration - Default (required). 
-#------------------------------------------------------------
-locals {
-  default_tags = var.default_tags_enabled ? {
-    deployedBy = format("AzureNoOpsTF [%s]", terraform.workspace)
-    env        = var.deploy_environment
-    workload   = var.workload_name
-  } : {}
-}

--- a/locals.tf
+++ b/locals.tf
@@ -6,8 +6,6 @@
 locals {
   backup_resource_group_name = var.backup_policy_id != null ? split("/", var.backup_policy_id)[4] : null
   backup_recovery_vault_name = var.backup_policy_id != null ? split("/", var.backup_policy_id)[8] : null
-  linux_domain_name_label    = lower(coalesce(var.internal_dns_name_label, local.linux_vm_name))
-  windows_domain_name_label  = lower(coalesce(var.internal_dns_name_label, local.windows_vm_name))
   nsg_inbound_rules = { for idx, security_rule in var.nsg_inbound_rules : security_rule.name => {
     idx : idx,
     security_rule : security_rule,

--- a/naming.tf
+++ b/naming.tf
@@ -64,16 +64,6 @@ data "popsrox_resource_name" "secnic" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "nsg" {
-  name          = var.workload_name
-  resource_type = "azurerm_network_security_group"
-  prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
-  suffixes      = compact([var.name_prefix == "" ? null : local.name_prefix, var.deploy_environment, local.name_suffix, var.use_naming ? "" : "nsg"])
-  use_slug      = var.use_naming
-  clean_input   = true
-  separator     = "-"
-}
-
 data "popsrox_resource_name" "disk" {
   name          = var.workload_name
   resource_type = "azurerm_managed_disk"

--- a/resources.virtual.machine.diagnostics.tf
+++ b/resources.virtual.machine.diagnostics.tf
@@ -50,28 +50,3 @@ resource "azurerm_virtual_machine_extension" "omsagentlinux" {
     }
   PROTECTED_SETTINGS
 }
-
-
-#--------------------------------------
-# azurerm monitoring diagnostics 
-#--------------------------------------
-/* resource "azurerm_monitor_diagnostic_setting" "nsg" {
-  count                      = var.log_analytics_workspace_id == null ? 0 : 1
-  name                       = var.os_type == "linux" ? lower("nsg-${local.linux_vm_name}-diag") : lower("nsg-${local.windows_vm_name}-diag")
-  target_resource_id         = var.existing_network_security_group_id == null ? azurerm_network_security_group.nsg[0].id : var.existing_network_security_group_id
-  storage_account_id         = var.storage_account_name != null ? data.azurerm_storage_account.storeacc[0].id : null
-  log_analytics_workspace_id = var.log_analytics_workspace_id
-
-  dynamic "log" {
-    for_each = var.nsg_diag_logs
-    content {
-      category = log.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-        days    = 0
-      }
-    }
-  }
-} */

--- a/variables.naming.tf
+++ b/variables.naming.tf
@@ -70,9 +70,3 @@ variable "os_disk_custom_name" {
   type        = string
   default     = null
 }
-
-variable "custom_dcr_name" {
-  description = "Custom name for Data collection rule association"
-  type        = string
-  default     = null
-}

--- a/variables.tags.tf
+++ b/variables.tags.tf
@@ -4,12 +4,6 @@
 ####################################
 # Tags Configuration    ##
 ####################################
-variable "default_tags_enabled" {
-  description = "Option to enable or disable default tags."
-  type        = bool
-  default     = true
-}
-
 variable "nic_add_tags" {
   description = "Extra tags to set on the network interface."
   type        = map(string)
@@ -32,22 +26,4 @@ variable "os_disk_add_tags" {
   description = "Extra tags to set on the OS disk."
   type        = map(string)
   default     = {}
-}
-
-variable "os_disk_tagging_enabled" {
-  description = "Should OS disk tagging be enabled? Defaults to `true`."
-  type        = bool
-  default     = true
-}
-
-variable "extensions_add_tags" {
-  description = "Extra tags to set on the VM extensions."
-  type        = map(string)
-  default     = {}
-}
-
-variable "os_disk_overwrite_tags" {
-  description = "True to overwrite existing OS disk tags instead of merging."
-  type        = bool
-  default     = false
 }

--- a/variables.virtual.machine.tf
+++ b/variables.virtual.machine.tf
@@ -234,38 +234,6 @@ variable "ip_forwarding_enabled" {
   default     = false
 }
 
-#####################################
-# VM Load Balancer Configuration   ##
-#####################################
-
-variable "attach_load_balancer" {
-  description = "True to attach this VM to a Load Balancer"
-  type        = bool
-  default     = false
-}
-
-variable "load_balancer_backend_pool_id" {
-  description = "Id of the Load Balancer Backend Pool to attach the VM."
-  type        = string
-  default     = null
-}
-
-###########################################
-# VM Application Gateway Configuration   ##
-###########################################
-
-variable "attach_application_gateway" {
-  description = "True to attach this VM to an Application Gateway"
-  type        = bool
-  default     = false
-}
-
-variable "application_gateway_backend_pool_id" {
-  description = "Id of the Application Gateway Backend Pool to attach the VM."
-  type        = string
-  default     = null
-}
-
 ####################################
 # VM Availability Configuration   ##
 ####################################
@@ -879,18 +847,6 @@ variable "enable_ultra_ssd_data_disk_storage_support" {
 #####################################
 # VM log analytics Configuration   ##
 #####################################
-
-variable "nsg_diag_logs" {
-  type        = any
-  description = "NSG Monitoring Category details for Azure Diagnostic setting"
-  default     = ["NetworkSecurityGroupEvent", "NetworkSecurityGroupRuleCounter"]
-}
-
-variable "log_analytics_workspace_id" {
-  type        = any
-  description = "The name of log analytics workspace resource id"
-  default     = null
-}
 
 variable "log_analytics_customer_id" {
   type        = any


### PR DESCRIPTION
## Summary

Classifies and removes all 15 `terraform_unused_declarations` warnings reported by tflint, using the A/B/C scheme established in the fleet cleanup playbook.

## Classification

| Category | Count | Action |
| --- | ---: | --- |
| **A** — truly dead code | 7 | Removed |
| **B** — intentional public API | 0 | n/a |
| **C** — WIP feature stubs | 10 | Removed; tracked in #15 |

### Category A — dead code (removed)

- `data.azurerm_client_config.current` (never read)
- `data.popsrox_resource_name.nsg` (orphaned after `local.vm_nsg_name` removal)
- `local.default_tags`
- `local.linux_domain_name_label`
- `local.windows_domain_name_label`
- `local.vm_nsg_name`
- `var.default_tags_enabled` (orphaned after `local.default_tags` removal)
- Commented-out `azurerm_monitor_diagnostic_setting.nsg` block in `resources.virtual.machine.diagnostics.tf`

### Category C — WIP feature stubs (removed, tracked in #15)

- Load Balancer attach: `attach_load_balancer`, `load_balancer_backend_pool_id`
- Application Gateway attach: `attach_application_gateway`, `application_gateway_backend_pool_id`
- Tagging variants: `extensions_add_tags`, `os_disk_overwrite_tags`, `os_disk_tagging_enabled`
- DCR naming: `custom_dcr_name`
- NSG diagnostics (only referenced from the commented-out block above): `nsg_diag_logs`, `log_analytics_workspace_id`

## Verification

```text
$ tflint --format=compact
(no issues)

$ terraform validate
Success! The configuration is valid.
```

Final unused-declaration count: **0** (was 15).

## Related

- Closes (partial): #12 (tflint baseline)
- Refs: #15 (Category C tracking)
